### PR TITLE
add a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rockylinux/rockylinux:8
+LABEL maintainer 'Jeff Ohrstrom <johrstrom@osc.edu>'
+
+
+RUN dnf update -y && dnf clean all && rm -rf /var/cache/dnf/*
+RUN dnf install -y \
+        python3.11 python3.11-pip
+
+COPY . /app
+
+RUN cd app; pip3 install -r requirements.txt
+
+WORKDIR /app
+
+ENV STREAMLIT_SERVER_PORT=8080
+ENV STREAMLIT_SERVER_HEADLESS=true
+ENV STREAMLIT_SERVER_ENABLECORS=false
+
+ENTRYPOINT streamlit run chatsqc.py


### PR DESCRIPTION
Add a Dockerfile so we can deploy it on OSC systems.

This does not execute `preprocess.py` though it likely should. I'm not entirely sure what it modifies/initializes so I didn't add it. 

I could use some clarity on that - what directories/files it initializes so that when the container is run it's available to whomever runs the container.